### PR TITLE
Add 'backup' option to dynamodb datasource type

### DIFF
--- a/docs/manifest-reference.md
+++ b/docs/manifest-reference.md
@@ -34,6 +34,8 @@ Exactly one of `dynamo` or `sql` subblocks _must_ be supplied
     - **sort_key** [DynamoKey, optional]: Specifies the field to be used as the table `sort key`
       - **name** [String, required]: Name of the field
       - **type** [String, optional]: The dynamodb type of the field (default `S` (string))
+    - **backup** [Bool, optional]: Sets whether to enable incrementatal backup on the table. Default `false`
+      - _be aware, enabling backup has a cost implication, so only use for tables that require it_
   - **sql** [Hash, optional]
     - _not yet implemented_
 
@@ -47,6 +49,7 @@ sources:
     dynamo:
       hash_key:
         name: email
+      backup: true
 
   customers:
     name: customers

--- a/pkg/graphql/source.go
+++ b/pkg/graphql/source.go
@@ -30,6 +30,7 @@ type (
 	DynamoSource struct {
 		HashKey *DynamoKeyType `yaml:"hash_key"`
 		SortKey *DynamoKeyType `yaml:"sort_key,omitempty"`
+		Backup  bool           `yaml:"backup,omitempty"`
 	}
 
 	// SQLSource represents a sql based db data source

--- a/pkg/graphql/source_template.go
+++ b/pkg/graphql/source_template.go
@@ -26,6 +26,7 @@ EOF
 resource "aws_dynamodb_table" "{{.Name}}" {
 	name 			= "${terraform.workspace}-{{.Name}}"
 	billing_mode 	= "PAY_PER_REQUEST"
+	{{ if .Dynamo.Backup }}point_in_time_recovery = enabled{{ end }}
 	hash_key 		= "{{.Dynamo.HashKey.Name}}"
 	{{ if .Dynamo.SortKey -}}
 	range_key		= "{{.Dynamo.SortKey.Name}}"


### PR DESCRIPTION
Allows marking up of dynamodb sources to have a `backup: true` which will enable incremental backups on the created table.

```yaml
sources:
  users:
    name: users
    dynamo:
      hash_key:
        name: email
      backup: true
```